### PR TITLE
Initialize the keycloak_enabled property

### DIFF
--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -125,6 +125,9 @@ class OpenIDConnect(object):
         # By default, we do not have a custom callback
         self._custom_callback = None
 
+        # Keycloak is not enabled by default
+        self.keycloak_enabled = False
+
         # get stuff from the app's config, which may override stuff set above
         if app is not None:
             self.init_app(app)


### PR DESCRIPTION
The keycloak_enabled property is only initialized if keycloak is enabled through the app.config, however it needs to be at least initialized no matter what to make this package work in our testing environment.